### PR TITLE
Let printers name be the displayName

### DIFF
--- a/GoogleCloudPrint.php
+++ b/GoogleCloudPrint.php
@@ -209,7 +209,7 @@ class GoogleCloudPrint {
 		$printers = array();
 		if (isset($jsonobj->printers)) {
 			foreach ($jsonobj->printers as $gcpprinter) {
-				$printers[] = array('name' =>$gcpprinter->name,'id' =>$gcpprinter->id);
+				$printers[] = array('name' =>$gcpprinter->displayName,'id' =>$gcpprinter->id);
 			}
 		}
 		return $printers;


### PR DESCRIPTION
The name parameter cannot be changed from the UI. Once displayName is changed, it is also unclear what the original name was.
