### PR TITLE
Google App Engine requirement

### DIFF
--- a/GoogleCloudPrint.php
+++ b/GoogleCloudPrint.php
@@ -177,8 +177,7 @@ class GoogleCloudPrint {
 			throw new Exception("Could not read the file. Please check file path.");
 		}
 		// Read file content
-		$contents = fread($handle, filesize($filepath));
-		fclose($handle);
+		$contents = file_get_contents($filepath);
 		
 		// Prepare post fields for sending print
 		$post_fields = array(


### PR DESCRIPTION
When using this in Google App Engine, it sends the file corrupted. This is due to using fread in on a GAE storage bucket.

To resolve this issue use file_get_contents instead